### PR TITLE
ui: robust price formatting + tiny-price counter; dark-only polish

### DIFF
--- a/src/lib/formatPrice.js
+++ b/src/lib/formatPrice.js
@@ -1,0 +1,53 @@
+export function formatPriceParts(input, { maxFrac = 6, minFrac = 1 } = {}) {
+  if (input == null) return { sign: "", int: "0", frac: "0", text: "0.0" };
+
+  let s = String(input).trim();
+  if (!/^\-?\d*\.?\d*$/.test(s)) {
+    const n = Number(input);
+    if (!Number.isFinite(n)) return { sign: "", int: "0", frac: "0", text: "0.0" };
+    s = String(n);
+  }
+
+  let sign = "";
+  if (s[0] === "-") { sign = "-"; s = s.slice(1); }
+  let [int = "", frac = ""] = s.split(".");
+  int = int.replace(/^0+(?=\d)/, "");
+  frac = (frac || "").replace(/[^0-9]/g, "");
+  if (!int) int = "0";
+
+  if (frac.length > maxFrac) {
+    const cut = frac.slice(0, maxFrac);
+    const next = frac.charCodeAt(maxFrac) - 48;
+    if (next >= 5) {
+      let carry = 1;
+      let out = cut.split("").map(c => c.charCodeAt(0) - 48);
+      for (let i = out.length - 1; i >= 0; i--) {
+        const v = out[i] + carry;
+        if (v >= 10) { out[i] = 0; carry = 1; }
+        else { out[i] = v; carry = 0; break; }
+      }
+      if (carry) {
+        frac = out.map(n => String.fromCharCode(48 + n)).join("");
+        let ci = int.split("").map(c => c.charCodeAt(0) - 48);
+        carry = 1;
+        for (let i = ci.length - 1; i >= 0; i--) {
+          const v = ci[i] + carry;
+          if (v >= 10) { ci[i] = 0; carry = 1; }
+          else { ci[i] = v; carry = 0; break; }
+        }
+        if (carry) ci.unshift(1);
+        int = ci.map(n => String.fromCharCode(48 + n)).join("");
+      } else {
+        frac = out.map(n => String.fromCharCode(48 + n)).join("");
+      }
+    } else {
+      frac = cut;
+    }
+  }
+
+  frac = frac.replace(/0+$/, "");
+  if (frac.length < minFrac) frac = frac.padEnd(minFrac, "0");
+
+  const text = `${sign}${int}.${frac}`;
+  return { sign, int, frac, text };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 :root{
-  --bg:#0b0f14;
+  --bg:#101011;
   --panel:#0d1320;
   --card:#000000;
   --neon:#1affd5;
@@ -115,7 +115,7 @@ a:hover{text-decoration:none; filter:brightness(1.1)}
 
 .header{
   position:sticky; top:0; backdrop-filter: blur(8px);
-  background: linear-gradient(180deg, rgba(13,19,32,.9), rgba(13,19,32,.6) 70%, transparent);
+  background: linear-gradient(180deg, rgba(13, 19, 32, .9), rgb(0 0 0 / 60%) 70%, transparent);
   border-bottom:1px solid rgba(122,222,255,.15);
   z-index:5;
 }
@@ -268,7 +268,7 @@ input[type="checkbox"]:disabled{
 .card{
   position:relative; 
   z-index:0;
-  background: linear-gradient(180deg, rgb(14 16 27 / 95%), rgb(22 26 33 / 80%));
+  background: linear-gradient(180deg, rgb(14 16 27 / 95%), rgb(0 0 0 / 80%));
   /* border:1px solid rgba(122,222,255,.16); */
   border-radius:16px;
   padding:14px 14px 12px;
@@ -982,6 +982,35 @@ hr.sep{border:0; border-top:1px dashed rgba(122,222,255,.2); margin:10px 0}
 .fdv-btn-primary{ background:var(--fdv-primary); color:var(--fdv-primary-fg) }
 .fdv-btn-secondary{ background:#1a2233; color:#e6e8eb; border:1px solid #233047 }
 
+/* Price formatting: integer + fractional parts, fits in tight boxes */
+.price {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.price .int { font-weight: 700; }
+.price .dot { opacity: .9; }
+.price .frac {
+  font-size: .9em;
+  opacity: .9;
+  max-width: 8ch;          /* clamp long decimals */
+  overflow: hidden;
+  text-overflow: ellipsis; /* hide extra decimals gracefully */
+}
+
+/* Price display (compact tiny values) */
+.price{ display:inline-flex; align-items:baseline; gap:.08em; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.price .int{ font-weight:700; }
+.price .dot{ opacity:.9; }
+.price .frac{ display:inline-flex; align-items:baseline; max-width:10ch; overflow:hidden; text-overflow:ellipsis; }
+.price .lead0{ opacity:.75; }
+.price .zrun{ opacity:.55; font-size:.85em; margin:0 .05em; }
+.price .sig{ font-weight:600; }
+/* Keep it readable on very narrow cells */
+.stats-grid .value .price{ max-width:100%; overflow:hidden; text-overflow:ellipsis; }
+
 @media (max-width: 920px){
   .fdv-modal-body{ grid-template-columns: 1fr; }
 }
@@ -991,4 +1020,37 @@ hr.sep{border:0; border-top:1px dashed rgba(122,222,255,.2); margin:10px 0}
   .fdv-row{ grid-template-columns: 1fr }
   .fdv-wallet{ order:-1 }
   .fdv-token-grid{ grid-template-columns: repeat(2, minmax(0,1fr)) }
+}
+
+/* Tiny price: raise/count badge and label it */
+.priceTiny{
+  display:inline-flex;
+  align-items:baseline;
+  gap:.35ch;
+  white-space:nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.priceTiny .base{ font-weight:700; }
+.priceTiny .sig{ font-weight:700; letter-spacing:.02em; }
+
+/* Lead-zeros count badge */
+.priceTiny .count{
+  position: relative;
+  top: -.3em;              /* slight raise */
+  font-size: .75em;        /* smaller digit */
+  line-height: 1;
+  /* padding: .05em .45em; */
+  border-radius: 999px;
+  color: var(--neon);
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--neon) 12%, transparent), transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--neon) 10%, transparent);
+}
+
+/* Add a small "0s" label so it's obvious what the number means */
+.priceTiny .count::after{
+  margin-left: .25ch;
+  opacity: .85;
+  font-weight: 600;
+  letter-spacing: .01em;
 }

--- a/src/views/meme/page.js
+++ b/src/views/meme/page.js
@@ -1,5 +1,5 @@
 import { MAX_CARDS } from '../../config/env.js';
-import { coinCard } from './cards.js';
+import { coinCard, priceHTML } from './cards.js';
 import { adCard } from '../../ads/load.js';
 import { sparklineSVG } from './render/sparkline.js';
 import { pctChipsHTML } from './render/chips.js';
@@ -507,8 +507,10 @@ function updateCardDOM(el, it) {
   // price
   const priceEl = el.querySelector('.v-price');
   if (priceEl) {
-    const txt = it.priceUsd ? ('$'+Number(it.priceUsd).toLocaleString(undefined,{maximumFractionDigits:6})) : '—';
-    if (priceEl.textContent !== txt) priceEl.textContent = txt;
+    const nextHtml = (it.priceUsd != null && Number.isFinite(+it.priceUsd))
+      ? priceHTML(+it.priceUsd)
+      : '—';
+    if (priceEl.innerHTML !== nextHtml) priceEl.innerHTML = nextHtml;
   }
 
   // score

--- a/src/views/profile/page.js
+++ b/src/views/profile/page.js
@@ -5,7 +5,7 @@ import { mountGiscus } from "../meme/chat.js";
 
 import sanitizeToken from "./sanitizeToken.js";
 import renderShell from "./render/shell.js";
-import { buildStatsGrid, setStat, setStatHtml } from "./render/statsGrid.js";
+import { buildStatsGrid, setStat, setStatHtml, setStatPrice } from "./render/statsGrid.js";
 import { setStatStatusByKey } from "./render/statuses.js";
 import { renderBarChart } from "./render/charts.js";
 import renderLinks from "./render/links.js";
@@ -156,7 +156,11 @@ function updateStatsGridLive(t, prev) {
   {
     const el = qv("price");
     const d = num(t.priceUsd) - num(prev?.priceUsd);
-    if (el) { el.textContent = Number.isFinite(t.priceUsd) ? `$${t.priceUsd.toFixed(6)}` : "—"; flashV(el, d); }
+    if (el) {
+      const grid = document.getElementById("statsGrid");
+      if (grid) setStatPrice(grid, t.priceUsd, { maxFrac: 6, minFrac: 1 });
+      flashV(el, d);
+    }
   }
   // liquidity
   {
@@ -321,8 +325,9 @@ export async function renderProfileView(input, { onBack } = {}) {
   } catch {}
 
   // Stats values (initial)
-  const PRICE_USD = Number.isFinite(t.priceUsd) ? `$${t.priceUsd.toFixed(6)}` : "—";
-  setStat(gridEl, 0, PRICE_USD);
+  // const PRICE_USD = Number.isFinite(t.priceUsd) ? `$${t.priceUsd.toFixed(6)}` : "—";
+  // setStat(gridEl, 0, PRICE_USD); // format to the decima;
+  setStatPrice(gridEl, t.priceUsd, { maxFrac: 9, minFrac: 1 });
   setStat(gridEl, 1, fmtMoney(t.liquidityUsd));
   setStat(gridEl, 2, fmtMoney(t.fdv ?? t.marketCap));
   setStat(gridEl, 3, Number.isFinite(t.liqToFdvPct) ? `${t.liqToFdvPct.toFixed(2)}%` : "—");

--- a/src/views/profile/render/statsGrid.js
+++ b/src/views/profile/render/statsGrid.js
@@ -1,4 +1,25 @@
 import { esc } from "../formatters.js";
+import { formatPriceParts } from "../../../lib/formatPrice.js";
+
+function toDecimalString(v) {
+  if (v == null) return "0.0";
+  let s = String(v).trim();
+  if (/^[+-]?\d+(\.\d+)?$/.test(s)) return s.includes(".") ? s : s + ".0";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "0.0";
+  if (Math.abs(n) >= 1) return n.toString().includes(".") ? n.toString() : n.toString() + ".0";
+  const m = n.toExponential().match(/^([+-]?\d(?:\.\d+)?)[eE]([+-]\d+)$/);
+  if (!m) return "0.0";
+  const coef = m[1].replace(".", "");
+  const exp = parseInt(m[2], 10);
+  if (exp >= 0) {
+    const pad = exp - (m[1].split(".")[1]?.length || 0);
+    return coef + (pad > 0 ? "0".repeat(pad) : "");
+  } else {
+    const k = -exp - 1;
+    return "0." + "0".repeat(k) + coef.replace(/^-/, "");
+  }
+}
 
 const STAT_DEF = [
   { key: "price",    label: "Price (USD)", short: "Price" },
@@ -15,6 +36,8 @@ const STAT_DEF = [
   { key: "bs24",     label: "24h Buys/Sells", short: "B/S 24" },
   { key: "buyratio", label: "Buy Ratio 24h",  short: "Buy%" },
 ];
+
+const PRICE_IDX = STAT_DEF.findIndex(d => d.key === "price");
 
 export function buildStatsGrid(container) {
   if (!container) return;
@@ -35,7 +58,6 @@ export function buildStatsGrid(container) {
   }
   container.replaceChildren(frag);
 }
-
 export function setStat(container, idx, text) {
   const el = container?.querySelectorAll(".stat .v")[idx];
   if (el) { el.classList.remove("sk"); el.textContent = text; }
@@ -44,4 +66,35 @@ export function setStat(container, idx, text) {
 export function setStatHtml(container, idx, html) {
   const el = container?.querySelectorAll(".stat .v")[idx];
   if (el) { el.classList.remove("sk"); el.innerHTML = html; }
+}
+
+export function setStatPrice(container, value, { maxFrac = 6, minFrac = 1, maxSig = 3 } = {}) {
+  const idx = PRICE_IDX;
+  const dec = toDecimalString(value);
+  const isNeg = String(value).trim().startsWith("-");
+  const [rawInt = "0", rawFrac = "0"] = dec.replace(/^[+-]?/, "").split(".");
+
+  if (rawInt !== "0") {
+    const p = formatPriceParts(dec, { maxFrac, minFrac });
+    const html = `
+      <span class="price" title="${esc(p.text)}">
+        ${p.sign ? `<span class="sign">${p.sign}</span>` : ""}
+        <span class="int">${p.int}</span><span class="dot">.</span><span class="frac">${p.frac}</span>
+      </span>
+    `;
+    return setStatHtml(container, idx, html);
+  }
+  const fracRaw = (rawFrac || "0").replace(/[^0-9]/g, "");
+  const leadZeros = (fracRaw.match(/^0+/) || [""])[0].length;
+  const sig = fracRaw.slice(leadZeros, leadZeros + Math.max(1, maxSig)) || "0";
+
+  const title = `${isNeg ? "-" : ""}0.${fracRaw || "0"}`;
+  const html = `
+    <span class="priceTiny" title="${esc(title)}" aria-label="${esc(`0.0 - ${leadZeros} decimal - ${sig}`)}">
+      <span class="base">0.0</span>
+      <span class="count">${leadZeros}</span>
+      <span class="sig">${esc(sig)}</span>
+    </span>
+  `;
+  setStatHtml(container, idx, html);
 }


### PR DESCRIPTION
StatsGrid and home cards use 0.0 + leading-zeros count (e.g. 0.0 - 6 DECIMAL - 810); preserve formatted HTML on card updates.

Black cards with theme-green border and raised count badge; non-blocking leaderboard snapshot+tail and agg fix.